### PR TITLE
feat(parse): #3 read langs and platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: clear lint test imports build start
+all: lint test imports build start
 
 ### Development
 
@@ -27,17 +27,25 @@ lint-fix: path
 	golangci-lint run --fix
 
 clear:
+	if [ -d "./bin" ]; then \
+		rm -rf ./bin; \
+	fi
+
+	if [ -f "$$HOME/.config/scruticode/settings.toml" ]; then \
+		rm $$HOME/.config/scruticode/settings.toml; \
+	fi
+
+clear-bin:
 	rm -rf ./bin
-	rm ~/.config/scruticode/settings.toml
 
 cache:
 	go clean -modcache
 
 ## https://github.com/golang-standards/project-layout/issues/113#issuecomment-1336514449
-build: clear fmt
+build: clear-bin fmt
 	GOARCH=amd64 go build -o ./bin/ScrutiCode ./src/main.go
 
-build-arm: clear fmt
+build-arm: clear-bin fmt
 	GOARCH=arm64 go build -o ./bin/ScrutiCode ./src/main.go
 
 test:

--- a/src/config/base.go
+++ b/src/config/base.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"Scruticode/src/constants"
+	"Scruticode/src/functions"
 	"log"
 	"os"
 	"os/user"
-	"path/filepath"
 )
 
 // This function should read a file located in $HOME/.config/scruticode/settings.toml
@@ -19,23 +19,8 @@ func ReadConfigFile() string {
 	}
 
 	filePath := usr.HomeDir + constants.ConfigFilePath
-	dirPath := filepath.Dir(filePath)
-
 	if _, errPath := os.Stat(filePath); os.IsNotExist(errPath) {
-		errCreateFolder := os.MkdirAll(dirPath, constants.DefaultFilePermissions)
-		if errCreateFolder != nil {
-			log.Println(constants.ErrMessageDirectory, errCreateFolder)
-
-			return ""
-		}
-
-		file, errCreateFile := os.Create(filePath)
-		if errCreateFile != nil {
-			log.Println(constants.ErrMessageFile, errCreateFile)
-
-			return ""
-		}
-		defer file.Close()
+		functions.InitConfigFile()
 	}
 
 	content, errReadFile := os.ReadFile(filePath)

--- a/src/constants/strings.go
+++ b/src/constants/strings.go
@@ -1,5 +1,6 @@
 package constants
 
 const (
-	TrueAsString = "true"
+	TrueAsString  = "true"
+	EmptyAsString = ""
 )

--- a/src/constants/strings.go
+++ b/src/constants/strings.go
@@ -1,6 +1,5 @@
 package constants
 
 const (
-	TrueAsString  = "true"
-	EmptyAsString = ""
+	TrueAsString = "true"
 )

--- a/src/functions/options/readme.go
+++ b/src/functions/options/readme.go
@@ -10,7 +10,7 @@ import (
 func Readme() types.BaseResponse {
 	// LOGIC
 	if _, err := os.Stat(constants.ReadmeFilePath); os.IsNotExist(err) {
-		utils.LoggerError(constants.FileNotFound, constants.ReadmeFilePath)
+		utils.LoggerErrorFile(constants.FileNotFound, constants.ReadmeFilePath)
 
 		return types.BaseResponse{
 			Status: constants.QualityCheckFailed,
@@ -18,7 +18,7 @@ func Readme() types.BaseResponse {
 	}
 
 	// LOG
-	utils.LoggerDebug(constants.FileFound, constants.ReadmeFilePath)
+	utils.LoggerDebugFile(constants.FileFound, constants.ReadmeFilePath)
 
 	// RESPONSE
 	return types.BaseResponse{

--- a/src/functions/process.go
+++ b/src/functions/process.go
@@ -78,16 +78,17 @@ func processKeyValues(keyValues []string) {
 		"dast":                 func() { log.Println("action for dast") },
 	}
 
+	const emptyAsString = ""
 	for _, pair := range keyValues {
 		key, value := parseKeyValuePair(pair)
-		if key == constants.EmptyAsString {
+		if key == emptyAsString {
 			continue
 		}
 
 		keyAsString := utils.ToAbsoluteString(value)
-		keyIsLangOrPlatform := key == "langs" || key == "platforms"
+		keyLangOrPlatform := key == "langs" || key == "platforms"
 
-		if keyIsLangOrPlatform {
+		if keyLangOrPlatform {
 			validations.ExtraLangConfig(keyAsString)
 			validations.ExtraPlatformConfig(keyAsString)
 		}

--- a/src/functions/process.go
+++ b/src/functions/process.go
@@ -3,6 +3,8 @@ package functions
 import (
 	"Scruticode/src/constants"
 	"Scruticode/src/functions/options"
+	"Scruticode/src/functions/utils"
+	"Scruticode/src/functions/validations"
 	"Scruticode/src/types"
 	"log"
 	"strings"
@@ -78,8 +80,16 @@ func processKeyValues(keyValues []string) {
 
 	for _, pair := range keyValues {
 		key, value := parseKeyValuePair(pair)
-		if key == "" {
+		if key == constants.EmptyAsString {
 			continue
+		}
+
+		keyAsString := utils.ToAbsoluteString(value)
+		keyIsLangOrPlatform := key == "langs" || key == "platforms"
+
+		if keyIsLangOrPlatform {
+			validations.ExtraLangConfig(keyAsString)
+			validations.ExtraPlatformConfig(keyAsString)
 		}
 
 		if isActionEnabled(value) {

--- a/src/functions/utils/conversions.go
+++ b/src/functions/utils/conversions.go
@@ -1,0 +1,11 @@
+package utils
+
+import "strings"
+
+func ToAbsoluteString(value string) string {
+	removeBrackets := strings.Trim(value, "[]")
+	removeDobleQuotes := strings.Trim(removeBrackets, `"`)
+	stringLang := strings.TrimSpace(removeDobleQuotes)
+
+	return stringLang
+}

--- a/src/functions/utils/conversions.go
+++ b/src/functions/utils/conversions.go
@@ -5,7 +5,7 @@ import "strings"
 func ToAbsoluteString(value string) string {
 	removeBrackets := strings.Trim(value, "[]")
 	removeDobleQuotes := strings.Trim(removeBrackets, `"`)
-	stringLang := strings.TrimSpace(removeDobleQuotes)
+	stringValue := strings.TrimSpace(removeDobleQuotes)
 
-	return stringLang
+	return stringValue
 }

--- a/src/functions/utils/logger.go
+++ b/src/functions/utils/logger.go
@@ -2,10 +2,10 @@ package utils
 
 import "log"
 
-func LoggerError(message, file string) {
+func LoggerErrorFile(message, file string) {
 	log.Fatalf("%s: %s\n", message, file)
 }
 
-func LoggerDebug(message string, file string) {
+func LoggerDebugFile(message string, file string) {
 	log.Printf("%s: %s\n", message, file)
 }

--- a/src/functions/validations/parse.go
+++ b/src/functions/validations/parse.go
@@ -1,0 +1,53 @@
+package validations
+
+import (
+	"log"
+	"slices"
+)
+
+func isValueAllowed(value string, allowedValues []string) bool {
+	return slices.Contains(allowedValues, value)
+}
+
+func extraConfig(value string, allowedValues []string, handler func(string)) {
+	if !isValueAllowed(value, allowedValues) {
+		return
+	}
+	handler(value)
+}
+
+func langHandler(lang string) {
+	switch lang {
+	case "golang":
+		{
+			log.Println("action for golang")
+		}
+	case "python":
+		{
+			log.Println("action for python")
+		}
+	case "typescript":
+	case "javascript":
+	}
+}
+
+func platformHandler(platform string) {
+	switch platform {
+	case "github":
+		{
+			log.Println("action for github")
+		}
+	case "gitlab":
+	case "azuredevops":
+	}
+}
+
+func ExtraLangConfig(lang string) {
+	var supportedLanguages = []string{"golang", "typescript", "javascript", "python"}
+	extraConfig(lang, supportedLanguages, langHandler)
+}
+
+func ExtraPlatformConfig(platform string) {
+	var supportedPlatforms = []string{"github", "gitlab", "azuredevops"}
+	extraConfig(platform, supportedPlatforms, platformHandler)
+}

--- a/src/functions/validations/parse.go
+++ b/src/functions/validations/parse.go
@@ -27,7 +27,13 @@ func langHandler(lang string) {
 			log.Println("action for python")
 		}
 	case "typescript":
+		{
+			log.Println("action for typescript")
+		}
 	case "javascript":
+		{
+			log.Println("action for javascript")
+		}
 	}
 }
 
@@ -38,7 +44,13 @@ func platformHandler(platform string) {
 			log.Println("action for github")
 		}
 	case "gitlab":
+		{
+			log.Println("action for gitlab")
+		}
 	case "azuredevops":
+		{
+			log.Println("action for azuredevops")
+		}
 	}
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -6,9 +6,10 @@ import (
 	"Scruticode/src/functions/arguments"
 )
 
+// https://stackoverflow.com/questions/56039154/is-it-really-bad-to-use-init-functions-in-go#56039373
+// https://leighmcculloch.com/posts/tool-go-check-no-globals-no-inits/
 func main() {
 	configuration := config.ReadConfigFile()
 	functions.ProcessConfigFile(configuration)
-	functions.InitConfigFile()
 	arguments.Generate()
 }

--- a/src/main.go
+++ b/src/main.go
@@ -6,8 +6,6 @@ import (
 	"Scruticode/src/functions/arguments"
 )
 
-// https://stackoverflow.com/questions/56039154/is-it-really-bad-to-use-init-functions-in-go#56039373
-// https://leighmcculloch.com/posts/tool-go-check-no-globals-no-inits/
 func main() {
 	configuration := config.ReadConfigFile()
 	functions.ProcessConfigFile(configuration)


### PR DESCRIPTION
Added function to read langs and platforms
Quite improvements for readability in general
InitConfig was not being handled properly

Remember to not use the `init` function.

https://stackoverflow.com/questions/56039154/is-it-really-bad-to-use-init-functions-in-go#56039373
https://leighmcculloch.com/posts/tool-go-check-no-globals-no-inits/

The linter will complain.